### PR TITLE
Correctly locate the target rack when moving node.

### DIFF
--- a/vdc.rb
+++ b/vdc.rb
@@ -62,7 +62,7 @@ def moveNode(node_id, target_cluster_id, target_rack_index, target_top_slot_inde
   original_rack = room['clusters'].map { |cluster| cluster['racks'] }.flatten.find do |r|
     node = r['nodes'].find { |n| n['id'] == node_id }
   end
-  target_rack = room['clusters'].find { |cluster| cluster['id'] = target_cluster_id }['racks'][target_rack_index]
+  target_rack = room['clusters'].find { |cluster| cluster['id'] == target_cluster_id }['racks'][target_rack_index]
   target_slot_indices = (target_top_slot_index...(target_top_slot_index - node['uNumber'])).to_a
   #puts "Checking for node between #{target_top_slot_index} and #{target_top_slot_index - node['uNumber']}"
   target_slot_occupied = target_rack['nodes'].any? do |n|


### PR DESCRIPTION
`=` was used instead of `==` when trying to locate the target cluster/rack!