### PR TITLE
Fix handling of event handlers

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -58,6 +58,11 @@ const listenNodeClickOnce = () => {
       $('#vdc-wrapper').css('cursor', 'grabbing');
       $('#vdc-wrapper').off('nodehover');
       $('#vdc-wrapper').off('nodeunhover');
+      $('#vdc-wrapper').off('slothover');
+      $('#vdc-wrapper').off('slotunhover');
+      $('#vdc-wrapper').off('rackhover');
+      $('#vdc-wrapper').off('rackunhover');
+      $('#vdc-wrapper').off('click');
       $('#vdc-wrapper').off('nodecontextmenu');
   
       requestAnimationFrame(() => setLabelVisibility(false));


### PR DESCRIPTION
Some handlers were not being unset in `listenNodeClickOnce`, but were then being added again, so after a few clicks on things we'd end up reacting multiple times to a single event.

Not sure if this is what caused the instability described in https://github.com/openflighthpc/flight-vdc-core/pull/9#issuecomment-2275965453 but I'm not able to reproduce that behaviour when running `flight-vdc-core`'s `feature/unrestricted-hover-events` branch.